### PR TITLE
Bump Gradle fra 8 til 9, fjern shadowjar, fjern multistage bygg i dockerfil

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,14 @@ jobs:
       image: ${{ steps.docker-build-push.outputs.image }}
     steps:
       - uses: actions/checkout@v7
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 21
+          cache: 'gradle'
+      - name: Build distribution
+        run: ./gradlew installDist
       - name: Publish Docker image
         uses: nais/docker-build-push@v0
         id: docker-build-push

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,5 @@
-FROM gradle:8-jdk21 AS builder
-
-ADD / /source
-WORKDIR /source
-RUN ./gradlew installDist
-
 FROM gcr.io/distroless/java21-debian12
 
-COPY --from=builder /source/build/install/modiapersonoversikt-innstillinger/lib /app/lib
+COPY build/install/*/lib /lib
 
-CMD ["java", "-cp", "/app/lib/*", "no.nav.modiapersonoversikt.MainKt"]
+ENTRYPOINT ["java", "-cp", "/lib/*", "no.nav.modiapersonoversikt.MainKt"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM gcr.io/distroless/java21-debian12
 
-COPY build/install/*/lib /lib
+COPY build/install/modiapersonoversikt-innstillinger/lib /lib
 
 ENTRYPOINT ["java", "-cp", "/lib/*", "no.nav.modiapersonoversikt.MainKt"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM gradle:8-jdk21 as builder
+FROM gradle:8-jdk21 AS builder
 
 ADD / /source
 WORKDIR /source
-RUN ./gradlew build
+RUN ./gradlew installDist
 
 FROM gcr.io/distroless/java21-debian12
 
-COPY --from=builder /source/build/libs/app.jar app.jar
+COPY --from=builder /source/build/install/modiapersonoversikt-innstillinger/lib /app/lib
 
-CMD ["app.jar"]
+CMD ["java", "-cp", "/app/lib/*", "no.nav.modiapersonoversikt.MainKt"]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,6 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-val mainClass = "no.nav.modiapersonoversikt.MainKt"
 val kotlinVersion = "2.4.10"
 val ktorVersion = "3.5.2"
 val prometheusVersion = "1.17.0"
@@ -12,7 +11,7 @@ val flywayVersion = "13.1.0"
 
 plugins {
     kotlin("jvm") version "2.3.0"
-    id("com.gradleup.shadow") version "8.3.9"
+    application
     idea
 }
 
@@ -67,7 +66,7 @@ dependencies {
     implementation("com.github.navikt.modia-common-utils:kotlin-utils:$modiaCommonVersion")
     implementation("com.github.navikt.modia-common-utils:ktor-utils:$modiaCommonVersion")
     implementation("com.github.navikt.modia-common-utils:crypto:$modiaCommonVersion")
-    compileOnly("org.flywaydb:flyway-core:$flywayVersion")
+    implementation("org.flywaydb:flyway-core:$flywayVersion")
     implementation("org.flywaydb:flyway-database-postgresql:$flywayVersion")
     implementation("com.github.seratch:kotliquery:1.9.1")
 
@@ -87,23 +86,3 @@ tasks.withType<KotlinCompile> {
     compilerOptions.freeCompilerArgs.set(listOf("-Xcontext-receivers"))
 }
 
-tasks {
-    shadowJar {
-        mergeServiceFiles {
-            setPath("META-INF/services/org.flywaydb.core.extensibility.Plugin")
-        }
-        archiveBaseName.set("app")
-        archiveClassifier.set("")
-        isZip64 = true
-        manifest {
-            attributes(
-                mapOf(
-                    "Main-Class" to mainClass,
-                ),
-            )
-        }
-    }
-    "build" {
-        dependsOn("shadowJar")
-    }
-}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Fjerna ShadowJar-plugin og er erstatta med innebygd application-plugin.

Fordelar:
 - Ingen tredjeparts byggeplugin å vedlikahalde
 - Flyway ServiceLoader fungerer automatisk — JARene ligg separat, ingen mergeServiceFiles nødvendig
 - Enklare build.gradle.kts

Det har vore krøll tidlegare med flyway + shadowJar fordi ein eksplisitt må sette servicefila til postgres-driveren for at flyway skal finne den. Det trengs ikkje lenger.

Fjernet multi-stage Docker-build for bla. å forenkle koden litt. Frå to FROM-stages (bygg inni Docker) til ein FROM (bygg i CI, Docker pakkar berre).

Fordelar:
 - Enklere Dockerfile. 3 linjer
 - Gradle-cache i CI fungerer via actions/setup-java cache: gradle
 - build/install/*/lib glob. ikke avhengig av prosjektnavn

Byggemiljøet er ikkje lenger isolert i Docker (avhenger av CI-agenten), men det er vanlegast praksis i Nav å ha det som steg i GitHub CI. Det nye workflow steger køyrer no /gradlew installDist før Docker-bygg.

Fordelar:
 - Gradle-cache gjenbrukes mellom køyringar. Raskare bygg
 - Konsistent med Nav-standardmønsteret

